### PR TITLE
fix-schedule-message-flood-the-stdout

### DIFF
--- a/controllers/phjob_scheduler.go
+++ b/controllers/phjob_scheduler.go
@@ -332,7 +332,7 @@ func (r *PHJobScheduler) scheduleByStrictOrder(phJobsRef *[]*primehubv1alpha1.Ph
 }
 
 func (r *PHJobScheduler) Schedule() {
-	r.Log.Info("start scheduling")
+	r.Log.V(1).Info("start scheduling")
 
 	ctx := context.Background()
 
@@ -341,7 +341,7 @@ func (r *PHJobScheduler) Schedule() {
 		r.Log.Error(err, "cannot get phjob list")
 		return
 	}
-	r.Log.Info("list completed", "len of phjobs", len(phJobList.Items))
+	r.Log.V(1).Info("list completed", "len of phjobs", len(phJobList.Items))
 
 	i := 0
 	for _, phJob := range phJobList.Items {
@@ -397,10 +397,10 @@ func (r *PHJobScheduler) Schedule() {
 		r.Log.Error(err, "cannot group phjob list")
 		return
 	}
-	r.Log.Info("group completed", "len of groups", len(*phJobsGroupMapping))
+	r.Log.V(1).Info("group completed", "len of groups", len(*phJobsGroupMapping))
 
 	for groupId, phJobs := range *phJobsGroupMapping {
-		r.Log.Info("start processing group", "group id", groupId)
+		r.Log.V(1).Info("start processing group", "group id", groupId)
 
 		r.sort(&phJobs, compareByCreationTimestamp)
 
@@ -428,5 +428,5 @@ func (r *PHJobScheduler) Schedule() {
 		}
 	}
 
-	r.Log.Info("end of scheduling")
+	r.Log.V(1).Info("end of scheduling")
 }

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.3.0
+	go.uber.org/zap v1.10.0
 	golang.org/x/sys v0.0.0-20191029155521-f43be2a4598c // indirect
 	golang.org/x/text v0.3.2 // indirect
 	k8s.io/api v0.0.0-20190918195907-bd6ac527cfd2


### PR DESCRIPTION
This PR add debug level logging, user can set argument `--debug=true` to log the debug informantion.

```
go run ./main.go --debug=true
2019-12-31T16:55:14.632+0800	DEBUG	scheduler.PhJob	start scheduling
2019-12-31T16:55:14.632+0800	DEBUG	scheduler.PhJob	list completed	{"len of phjobs": 0}
2019-12-31T16:55:14.632+0800	DEBUG	scheduler.PhJob	group completed	{"len of groups": 0}
2019-12-31T16:55:14.632+0800	DEBUG	scheduler.PhJob	end of scheduling
2019-12-31T16:55:15.635+0800	DEBUG	scheduler.PhJob	start scheduling
2019-12-31T16:55:15.635+0800	DEBUG	scheduler.PhJob	list completed	{"len of phjobs": 0}
2019-12-31T16:55:15.635+0800	DEBUG	scheduler.PhJob	group completed	{"len of groups": 0}
```

Note: debug flag default set to false.