### PR TITLE
fix set starttime and finishtime logic

### DIFF
--- a/controllers/phjob_controller.go
+++ b/controllers/phjob_controller.go
@@ -371,16 +371,24 @@ func (r *PhJobReconciler) updateStatus(
 	}
 
 	// set StartTime.
-	phJob.Status.StartTime = getStartTime(pod)
-	// log.Info("updateStatus", "pod status", pod.Status)
+	if phJob.Status.StartTime == nil {
+		now := metav1.Now()
+		phJob.Status.StartTime = &now
+	}
 
 	if pod.Status.Phase == corev1.PodSucceeded {
 		phJob.Status.Phase = primehubv1alpha1.JobSucceeded
-		phJob.Status.FinishTime = getFinishTime(pod)
+		if phJob.Status.FinishTime == nil {
+			now := metav1.Now()
+			phJob.Status.FinishTime = &now
+		}
 	}
 	if pod.Status.Phase == corev1.PodFailed {
 		phJob.Status.Phase = primehubv1alpha1.JobFailed
-		phJob.Status.FinishTime = getFinishTime(pod)
+		if phJob.Status.FinishTime == nil {
+			now := metav1.Now()
+			phJob.Status.FinishTime = &now
+		}
 		if len(pod.Status.ContainerStatuses) > 0 {
 			phJob.Status.Reason = pod.Status.ContainerStatuses[0].State.Terminated.Reason
 			phJob.Status.Message = pod.Status.ContainerStatuses[0].State.Terminated.Message
@@ -388,6 +396,10 @@ func (r *PhJobReconciler) updateStatus(
 	}
 	if pod.Status.Phase == corev1.PodUnknown {
 		phJob.Status.Phase = primehubv1alpha1.JobUnknown
+		if phJob.Status.FinishTime == nil {
+			now := metav1.Now()
+			phJob.Status.FinishTime = &now
+		}
 	}
 	if pod.Status.Phase == corev1.PodRunning {
 		phJob.Status.Phase = primehubv1alpha1.JobRunning
@@ -423,8 +435,15 @@ func (r *PhJobReconciler) handleTTL(ctx context.Context, phJob *primehubv1alpha1
 	currentTime := time.Now()
 	ttlDuration := time.Second * time.Duration(*phJob.Spec.TTLSecondsAfterFinished)
 
-	if phJob.Status.FinishTime == nil {
+	if phJob.Status.StartTime == nil && phJob.Status.FinishTime == nil {
+		log.Info("phjob in final phase (Succeeded, Failed, Unknown) without finish time and start time, it is incorrect!!!")
+		log.Info("will ignore it and do nothing.")
 		return nil
+	}
+
+	if phJob.Status.FinishTime == nil {
+		log.Info("phjob in final phase (Succeeded, Failed, Unknown) without finish time, using start time as finish time")
+		phJob.Status.FinishTime = phJob.Status.StartTime
 	}
 
 	if currentTime.After(phJob.Status.FinishTime.Add(ttlDuration)) {
@@ -506,7 +525,7 @@ func (r *PhJobReconciler) deletePod(ctx context.Context, podkey client.ObjectKey
 	return nil
 }
 
-func inFinalPhase(phase primehubv1alpha1.PhJobPhase) bool { // TODO: change the name
+func inFinalPhase(phase primehubv1alpha1.PhJobPhase) bool {
 	switch phase {
 	case primehubv1alpha1.JobSucceeded, primehubv1alpha1.JobFailed, primehubv1alpha1.JobUnknown, primehubv1alpha1.JobCancelled:
 		return true


### PR DESCRIPTION
fix set starttime and finishtime logic
start time will be set as the current time the job is from pending ready and create the pod and update the status for the first time.
finish time will be set as the current time the job is failed or unknown

because a pod might not have start time and finish time even when it is failed
for example, Evicted
```
pod:
status:
  message: 'The node was low on resource: memory. Container main was using 1604892Ki,
    which exceeds its request of 1G. '
  phase: Failed
  reason: Evicted
  startTime: "2020-01-07T07:20:10Z"
```