### PR TITLE
Setting job starttime after phjob is in running phase, also sync Reason and message to phjob 

### DIFF
--- a/controllers/phjob_controller.go
+++ b/controllers/phjob_controller.go
@@ -375,8 +375,8 @@ func (r *PhJobReconciler) updateStatus(
 			now := metav1.Now()
 			phJob.Status.FinishTime = &now
 		}
-		phJob.Status.Reason = "pod is finish and exit successfully."
-		phJob.Status.Message = "Finished"
+		phJob.Status.Reason = "Finished"
+		phJob.Status.Message = "pod is finish and exit successfully."
 	}
 
 	if pod.Status.Phase == corev1.PodFailed {
@@ -398,15 +398,15 @@ func (r *PhJobReconciler) updateStatus(
 			phJob.Status.FinishTime = &now
 		}
 		if len(pod.Status.Conditions) > 0 {
-			phJob.Status.Reason = pod.Status.Conditions[0].Message
-			phJob.Status.Message = pod.Status.Conditions[0].Reason
+			phJob.Status.Reason = pod.Status.Conditions[0].Reason
+			phJob.Status.Message = pod.Status.Conditions[0].Message
 		}
 	}
 
 	if pod.Status.Phase == corev1.PodPending {
 		if len(pod.Status.Conditions) > 0 {
-			phJob.Status.Reason = pod.Status.Conditions[0].Message
-			phJob.Status.Message = pod.Status.Conditions[0].Reason
+			phJob.Status.Reason = pod.Status.Conditions[0].Reason
+			phJob.Status.Message = pod.Status.Conditions[0].Message
 		}
 	}
 
@@ -417,8 +417,8 @@ func (r *PhJobReconciler) updateStatus(
 			now := metav1.Now()
 			phJob.Status.StartTime = &now
 		}
-		phJob.Status.Reason = "pod is created and starts running."
-		phJob.Status.Message = "Running"
+		phJob.Status.Reason = "Running"
+		phJob.Status.Message = "pod is created and starts running."
 	}
 
 	log.Info("phJob phase: ", "phase", phJob.Status.Phase)

--- a/controllers/phjob_controller.go
+++ b/controllers/phjob_controller.go
@@ -375,6 +375,8 @@ func (r *PhJobReconciler) updateStatus(
 			now := metav1.Now()
 			phJob.Status.FinishTime = &now
 		}
+		phJob.Status.Reason = "pod is finish and exit successfully."
+		phJob.Status.Message = "Finished"
 	}
 
 	if pod.Status.Phase == corev1.PodFailed {
@@ -409,13 +411,16 @@ func (r *PhJobReconciler) updateStatus(
 	}
 
 	if pod.Status.Phase == corev1.PodRunning {
+		phJob.Status.Phase = primehubv1alpha1.JobRunning
 		// set StartTime.
 		if phJob.Status.StartTime == nil {
 			now := metav1.Now()
 			phJob.Status.StartTime = &now
 		}
-		phJob.Status.Phase = primehubv1alpha1.JobRunning
+		phJob.Status.Reason = "pod is created and starts running."
+		phJob.Status.Message = "Running"
 	}
+
 	log.Info("phJob phase: ", "phase", phJob.Status.Phase)
 	if err := r.updatePhJobStatus(ctx, phJob); err != nil {
 		return err


### PR DESCRIPTION
The reason of this ticket is because the job will get starttime when it is Ready
but if k8s has no enough resources, pod will keep in Pending (phjob in Ready)

We shouldn't consider it as start, the starttime should only be set when the pod is actually running (phjob in running phase)

now the job will be get start time when it enter running phase and get finish time when it Failed, Succeed and Unknown (Final Phase)

---
This PR also  fix "Reason and message should sync to phjob even it's not failed"
