### PR TITLE
show correct messages when nodelost even the pod is still running

### DIFF
--- a/controllers/phjob_controller.go
+++ b/controllers/phjob_controller.go
@@ -432,8 +432,16 @@ func (r *PhJobReconciler) updateStatus(
 			now := metav1.Now()
 			phJob.Status.StartTime = &now
 		}
-		phJob.Status.Reason = primehubv1alpha1.JobReasonPodRunning
-		phJob.Status.Message = "Job is currently running"
+
+		// when node lost, pod will keep in running phase,
+		// so we should show the correct message
+		if pod.Status.Reason == "NodeLost" {
+			phJob.Status.Reason = primehubv1alpha1.JobReasonPodRunning
+			phJob.Status.Message = pod.Status.Message
+		} else {
+			phJob.Status.Reason = primehubv1alpha1.JobReasonPodRunning
+			phJob.Status.Message = "Job is currently running"
+		}
 	}
 
 	log.Info("phJob phase: ", "phase", phJob.Status.Phase)


### PR DESCRIPTION
Signed-off-by: Jack Lin <chanyi.jack.lin@infuseai.io>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

** PR checklist **

- [*] Ensure you have added or ran the appropriate tests for your PR.
- [ *] DCO signed

**What type of PR is this?**
feature

**What this PR does / why we need it**:
when the node lost, pod will keep in running phase so as phjob.
we should show the correct message to inform users that the node has lost even the phjob shows running.

**Which issue(s) this PR fixes**:
as above

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
None
```
