### PR TITLE
if prev phjob is still running, phschedule will not spawn next phjob

### DIFF
--- a/config/samples/primehub_v1alpha1_phschedule.yaml
+++ b/config/samples/primehub_v1alpha1_phschedule.yaml
@@ -154,3 +154,40 @@ status:
   invalid: false
   # Next run time
   nextRunTime: "2020-03-01T00:00:00Z"
+---
+apiVersion: primehub.io/v1alpha1
+kind: PhSchedule
+metadata:
+  generateName: schedule-
+  namespace: hub
+spec:
+  # The schedule setting
+  recurrence:
+    type: "custom"
+    # The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
+    cron: "*/1 * * * *"
+  jobTemplate:
+    # Standard object's metadata of the jobs created from this template.
+    metadata:
+      annotations: {}
+      labels: {}
+    # Specification of the desired behavior of the phjob.
+    spec:
+      command: |
+        echo start
+        data
+        sleep 100 # test concurrency
+        date
+        echo complete
+      displayName: hello
+      userId: 65fa98af-62d7-4efc-8587-193024d1ff0e
+      userName: phadmin
+      groupId: da4cab31-5d86-4313-8084-e3d9f554e4d8
+      groupName: phusers
+      image: base-notebook
+      instanceType: cpu-only
+status:
+  # If the cron format correct
+  invalid: false
+  # Next run time
+  nextRunTime: "2020-03-01T00:00:00Z"


### PR DESCRIPTION
Signed-off-by: ChanYiLin <j5111261112@gmail.com>
Signed-off-by: Jack Lin <chanyi.jack.lin@infuseai.io>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**What type of PR is this?**
new feature

**What this PR does / why we need it**:
if prev phjob is still running, phschedule will not spawn next phjob

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
