### PR TITLE
Add error-handling

### DIFF
--- a/controllers/phdeployment_controller.go
+++ b/controllers/phdeployment_controller.go
@@ -268,7 +268,7 @@ func (r *PhDeploymentReconciler) updateStatus(ctx context.Context, phDeployment 
 	for _, p := range failedPods {
 		if p.isImageError || p.isTerminated {
 			phDeployment.Status.Phase = primehubv1alpha1.DeploymentFailed
-			phDeployment.Status.Messsage = "phDeployment has failed because of wrong image settings." + r.explain(failedPods)
+			phDeployment.Status.Messsage = "Failed because of wrong image settings." + r.explain(failedPods)
 			phDeployment.Status.Replicas = phDeployment.Spec.Predictors[0].Replicas
 			phDeployment.Status.AvailableReplicas = 0
 			phDeployment.Status.Endpoint = ""
@@ -277,7 +277,7 @@ func (r *PhDeploymentReconciler) updateStatus(ctx context.Context, phDeployment 
 
 		if p.isUnschedulable {
 			phDeployment.Status.Phase = primehubv1alpha1.DeploymentFailed
-			phDeployment.Status.Messsage = "phDeployment has failed because of certain pods unschedulable." + r.explain(failedPods)
+			phDeployment.Status.Messsage = "Failed because of certain pods unschedulable." + r.explain(failedPods)
 			phDeployment.Status.Replicas = phDeployment.Spec.Predictors[0].Replicas
 			phDeployment.Status.AvailableReplicas = 0
 			phDeployment.Status.Endpoint = ""
@@ -287,7 +287,7 @@ func (r *PhDeploymentReconciler) updateStatus(ctx context.Context, phDeployment 
 
 	if seldonDeploymentAvailableTimeout {
 		phDeployment.Status.Phase = primehubv1alpha1.DeploymentFailed
-		phDeployment.Status.Messsage = "phDeployment has failed because the deployment is not available for over 5 min" + r.explain(failedPods)
+		phDeployment.Status.Messsage = "Failed because the deployment is not available for over 5 min" + r.explain(failedPods)
 		phDeployment.Status.Replicas = phDeployment.Spec.Predictors[0].Replicas
 		phDeployment.Status.AvailableReplicas = 0
 
@@ -305,7 +305,7 @@ func (r *PhDeploymentReconciler) updateStatus(ctx context.Context, phDeployment 
 
 	if seldonDeployment.Status.State == seldonv1.StatusStateFailed {
 		phDeployment.Status.Phase = primehubv1alpha1.DeploymentFailed
-		phDeployment.Status.Messsage = "phDeployment has failed because the seldon deployment on k8s is failed " + r.explain(failedPods)
+		phDeployment.Status.Messsage = "Failed because the seldon deployment on k8s is failed " + r.explain(failedPods)
 		phDeployment.Status.Replicas = phDeployment.Spec.Predictors[0].Replicas
 		phDeployment.Status.AvailableReplicas = 0
 


### PR DESCRIPTION
** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

Add error handling feature for PhDeployment, because SeldonDeployment doesn't tell us anything going wrong.

**What this PR does / why we need it**:

* Error handling for seldon deployment failure
* fast failed if we have got a reason


**Which issue(s) this PR fixes**:

ch8807


**Does this PR introduce a user-facing change?**:

None

**Special notes for your reviewer**:

We have some examples at the bottom.



## Error Handling Sample


### Case: set a bad image: jupyter/base-notebook (application terminated)

```yaml
    message: |-
      Failed because of wrong image settings.
      pod[user-defined-postfix-d8dfd9678-bf65v] failed
        container state: Terminated, reason: Completed, message , exit-code: 0
      pod[user-defined-postfix-d8dfd9678-zs6vq] failed
        container state: Terminated, reason: Completed, message , exit-code: 0
```

### Case: set a non-existing image


```yaml
    message: |-
      Failed because of wrong image settings.
      pod[user-defined-postfix-66dff9d6ff-r78sb] failed
        container state: Waiting, reason: ErrImagePull, message rpc error: code = Unknown desc = Error response from daemon: repository no-such-image not found: does not exist or no pull access
      pod[user-defined-postfix-66dff9d6ff-l46g9] failed
        container state: Waiting, reason: ErrImagePull, message rpc error: code = Unknown desc = Error response from daemon: repository no-such-image not found: does not exist or no pull access
      pod[user-defined-postfix-66dff9d6ff-chwp9] failed
        reason: Unschedulable, message 0/3 nodes are available: 3 Insufficient cpu.
```

OR

```yaml
    message: |-
      Failed because of wrong image settings.
      pod[user-defined-postfix-66dff9d6ff-smz9b] failed
        container state: Waiting, reason: ImagePullBackOff, message Back-off pulling image "no-such-image"
      pod[user-defined-postfix-66dff9d6ff-chwp9] failed
        container state: Waiting, reason: ImagePullBackOff, message Back-off pulling image "no-such-image"
```

### Case: cluster resource is not enough

```yaml
    message: |-
      Failed because of certain pods unschedulable.
      pod[user-defined-postfix-555544947c-hgqvj] failed
        reason: Unschedulable, message 0/3 nodes are available: 3 Insufficient cpu.
      pod[user-defined-postfix-555544947c-bkcb6] failed
        reason: Unschedulable, message 0/3 nodes are available: 3 Insufficient cpu.
      pod[user-defined-postfix-555544947c-hgbpj] failed
        reason: Unschedulable, message 0/3 nodes are available: 3 Insufficient cpu.
```