### PR TITLE
[Cherrypick 2.8] Fix env dataset for bash

### DIFF
--- a/pkg/graphql/spawn.go
+++ b/pkg/graphql/spawn.go
@@ -544,8 +544,14 @@ func (spawner *Spawner) applyVolumeForEnvDataset(dataset DtoDataset) {
 		if !valid {
 			continue
 		} else {
+			// For backward compatibility in env
 			spawner.env = append(spawner.env, corev1.EnvVar{
 				Name:  envKey,
+				Value: value,
+			})
+			// Actually, hyphen is not supported in bash
+			spawner.env = append(spawner.env, corev1.EnvVar{
+				Name:  strings.ReplaceAll(envKey, "-", "_"),
 				Value: value,
 			})
 		}

--- a/pkg/graphql/spawn_test.go
+++ b/pkg/graphql/spawn_test.go
@@ -495,7 +495,7 @@ func TestDatasetNfs(t *testing.T) {
 func TestDatasetEnv(t *testing.T) {
 
 	dataset := DtoDataset{
-		Name: "ds",
+		Name: "TEST-ENV",
 		Spec: DtoDatasetSpec{
 			Type: "env",
 			Variables: map[string]string{
@@ -506,6 +506,20 @@ func TestDatasetEnv(t *testing.T) {
 
 	spawner := &Spawner{}
 	spawner.applyVolumeForEnvDataset(dataset)
+
+	spawnerTests := []struct {
+		key   string
+		value string
+	}{
+		{"TEST-ENV_FOO", "bar"},
+		{"TEST_ENV_FOO", "bar"},
+	}
+	for idx, test := range spawnerTests {
+		t.Run(test.key, func(t *testing.T) {
+			assert.Equal(t, test.key, spawner.env[idx].Name)
+			assert.Equal(t, test.value, spawner.env[idx].Value)
+		})
+	}
 
 	tests := []struct {
 		key         string


### PR DESCRIPTION
Cherrypick for
https://app.clubhouse.io/infuseai/story/11389/bug-env-dataset-will-contain-invalid-character-hyphen-if-the-dataset-name-include-hyphen