### PR TITLE
Enlarge the license timeout to 60 minutes

### DIFF
--- a/ee/controllers/license_controller.go
+++ b/ee/controllers/license_controller.go
@@ -187,7 +187,7 @@ func (r *LicenseReconciler) EnsureLicense(mgr ctrl.Manager) (err error) {
 
 	// ref: https://github.com/kubernetes/test-infra/pull/15489/files
 	// Wait for cachesync then ensure license installed
-	mgrSyncCtx, mgrSyncCtxCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	mgrSyncCtx, mgrSyncCtxCancel := context.WithTimeout(context.Background(), 10 * 60 * time.Second)
 	defer mgrSyncCtxCancel()
 
 	if synced := mgr.GetCache().WaitForCacheSync(mgrSyncCtx.Done()); !synced {


### PR DESCRIPTION
Signed-off-by: popcorny <celu@infuseai.io>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

** PR checklist **

- [X] Ensure you have added or ran the appropriate tests for your PR.
- [X] DCO signed

**What type of PR is this?**
Bug fix

**What this PR does / why we need it**:
The license key sync timeout is too short and would lead to crashloopbackoff

**Which issue(s) this PR fixes**:
https://app.clubhouse.io/infuseai/story/12084/jobs-is-always-pending-in-demo-a
https://app.clubhouse.io/infuseai/story/12089/speed-up-primehub-controller-ensurelicense

**Special notes for your reviewer**:
The cache should get sync eventually. So i consider the long cache sync period should be more reasonable.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
```
