### PR TITLE
Refresh ldconfig cache

### DIFF
--- a/ee/scripts/job/run-job.sh
+++ b/ee/scripts/job/run-job.sh
@@ -109,6 +109,9 @@ if [[ "${GRANT_SUDO}" == "true" ]]; then
   fi
 fi
 
+# Refresh ldconfig cache
+ldconfig
+
 monitoring_start
 
 # Run Command


### PR DESCRIPTION
** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

bugfix

**What this PR does / why we need it**:

Accessing GPU devices failed, caused by ldconfig cache too old to find libraries. We could fix it by rerun ldconfig

**Which issue(s) this PR fixes**:

ch13904
