### PR TITLE
fix the run-app script with array expansion with quoted string

### DIFF
--- a/script/run-app
+++ b/script/run-app
@@ -8,15 +8,11 @@ PRIMEHUB_APP_ID=${PRIMEHUB_APP_ID}
 PRIMEHUB_APP_ROOT=${PRIMEHUB_APP_ROOT}
 PRIMEHUB_APP_BASE_URL=${PRIMEHUB_APP_BASE_URL}
 
-command=$1
-shift
-args=$@
-
 # Prepare PrimeHub App Root
 mkdir -p ${PRIMEHUB_APP_ROOT}
 
 # Run Command
-eval exec ${command} ${args}
+exec "$@"
 rc=$?
 
 exit ${rc}


### PR DESCRIPTION
run-app should expand the command argument with quote