### PR TITLE
[Bugfix] ch17267 fix phapplication deployment will generate multiple rs

### DIFF
--- a/pkg/graphql/spawn.go
+++ b/pkg/graphql/spawn.go
@@ -666,7 +666,15 @@ func (spawner *Spawner) applyVolumeForNfsDataset(
 }
 
 func (spawner *Spawner) applyVolumeForEnvDataset(dataset DtoDataset) {
-	for key, value := range dataset.Spec.Variables {
+	// The Map of Golang is implemented by hashmap, it doesn't guarantee the order of fetching keys
+	keys := make([]string, 0, len(dataset.Spec.Variables))
+	for _, k := range dataset.Spec.Variables {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		value := dataset.Spec.Variables[key]
 		envKey, valid := transformEnvKey(dataset.Name, key)
 		if !valid {
 			continue

--- a/pkg/graphql/spawn.go
+++ b/pkg/graphql/spawn.go
@@ -668,7 +668,7 @@ func (spawner *Spawner) applyVolumeForNfsDataset(
 func (spawner *Spawner) applyVolumeForEnvDataset(dataset DtoDataset) {
 	// The Map of Golang is implemented by hashmap, it doesn't guarantee the order of fetching keys
 	keys := make([]string, 0, len(dataset.Spec.Variables))
-	for _, k := range dataset.Spec.Variables {
+	for k := range dataset.Spec.Variables {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bugfix

**What this PR does / why we need it**:
Due to the map of golang is implemented by hashmap, it doesn't guarantee the order of fetching keys.
It will cause phapplication to generate multiple ReplicaSet if exists env dataset. The order of the env dataset will be random.
We need to sort the keys of env dataset to guarantee the order of env dataset.

**Which issue(s) this PR fixes**:
ch17267

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
```
