### PR TITLE
Support airgap image prefix for PhDeployment and PhApps

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -2,6 +2,10 @@ primehubUrl: https://primehub.local
 graphqlEndpoint: https://primehub.local/api/graphql
 graphqlSecret: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
+# imagePrefix is used in air-gapped environment
+# it is an optional setting
+imagePrefix: primehub.airgap:5000/
+
 customImage:
   pushSecretName: primehub-controller-custom-image-push-secret
   # Prefix for image. (e.g. 'gcr.io/infuseai' for 'gcr.io/infuseai/primehub-controller:be20ee69c5')

--- a/controllers/phapplication_controller_test.go
+++ b/controllers/phapplication_controller_test.go
@@ -88,7 +88,7 @@ func TestPhApplicationReconciler_Reconcile(t *testing.T) {
 	}
 	fakeClient := fake.NewFakeClientWithScheme(scheme, []runtime.Object{phApplication}...)
 	primehubCache := phcache.NewPrimeHubCache(nil)
-	r := &PhApplicationReconciler{fakeClient, logger, scheme, primehubCache, false, "primehub-store", "http://example.primehub.io"}
+	r := &PhApplicationReconciler{fakeClient, logger, scheme, primehubCache, false, "primehub-store", "http://example.primehub.io", ""}
 	req := controllerruntime.Request{}
 
 	primehubCache.InstanceType.Set("instanceType:"+instanceType, &graphql.DtoInstanceType{

--- a/ee/controllers/phdeployment_controller.go
+++ b/ee/controllers/phdeployment_controller.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"primehub-controller/pkg/airgap"
 	"reflect"
 	"regexp"
 	"sort"
@@ -51,6 +52,7 @@ type PhDeploymentReconciler struct {
 	MlflowModelStorageInitializerPullPolicy corev1.PullPolicy
 	PhfsEnabled                             bool
 	PhfsPVC                                 string
+	ImagePrefix                             string
 }
 
 type FailedPodStatus struct {
@@ -1026,6 +1028,7 @@ func (r *PhDeploymentReconciler) buildDeployment(ctx context.Context, phDeployme
 		return nil, err
 	}
 
+	airgap.ApplyAirGapImagePrefix(&deployment.Spec.Template.Spec, r.ImagePrefix)
 	return deployment, nil
 }
 

--- a/ee/main.go
+++ b/ee/main.go
@@ -155,6 +155,7 @@ func main() {
 		PhfsEnabled:   phfsEnabled,
 		PhfsPVC:       phfsPVC,
 		PrimeHubURL:   viper.GetString("primehubUrl"),
+		ImagePrefix:   viper.GetString("imagePrefix"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PhApplication")
 		os.Exit(1)
@@ -288,6 +289,7 @@ func createDeploymentReconciler(err error, mgr manager.Manager, graphqlClient gr
 		MlflowModelStorageInitializerPullPolicy: mlflowModelStorageInitializerPullPolicy,
 		PhfsEnabled:                             phfsEnabled,
 		PhfsPVC:                                 phfsPVC,
+		ImagePrefix:                             viper.GetString("imagePrefix"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PhDeployment")
 		os.Exit(1)
@@ -327,6 +329,7 @@ func loadConfig() {
 		"modelDeployment.mlflowModelStorageInitializer.image.tag",
 		"modelDeployment.mlflowModelStorageInitializer.image.pullPolicy",
 	}
+
 	if viper.GetBool("modelDeployment.enabled") {
 		configs = append(configs, modelConfigs...)
 	}

--- a/main.go
+++ b/main.go
@@ -107,6 +107,7 @@ func main() {
 		PhfsEnabled:   phfsEnabled,
 		PhfsPVC:       phfsPVC,
 		PrimeHubURL:   viper.GetString("primehubUrl"),
+		ImagePrefix:   viper.GetString("imagePrefix"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PhApplication")
 		os.Exit(1)

--- a/pkg/airgap/airgap.go
+++ b/pkg/airgap/airgap.go
@@ -1,0 +1,26 @@
+package airgap
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"strings"
+)
+
+func ApplyAirGapImagePrefix(podSpec *corev1.PodSpec, imagePrefix string) *corev1.PodSpec {
+	initContainers := podSpec.InitContainers
+	for i := range initContainers {
+		PatchContainerImage(&initContainers[i], imagePrefix)
+	}
+
+	containers := podSpec.Containers
+	for i := range containers {
+		PatchContainerImage(&containers[i], imagePrefix)
+	}
+
+	return podSpec
+}
+
+func PatchContainerImage(container *corev1.Container, imagePrefix string) {
+	if !strings.Contains(container.Image, imagePrefix) {
+		container.Image = imagePrefix + container.Image
+	}
+}


### PR DESCRIPTION
** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

enhancement

**What this PR does / why we need it**:

support air-gap image prefix for phapps and phdeployments

**Which issue(s) this PR fixes**:

sc-24401

**Special notes for your reviewer**:

We introduce a new field `imagePrefix` to set the preifx

```yaml
# imagePrefix is used in air-gapped environment
# it is an optional setting
imagePrefix: primehub.airgap:5000/
```

image-tag for verifying: `sc24401-46dc97`