### PR TITLE
Change the phjob requeue frequency

### DIFF
--- a/ee/controllers/phjob_controller.go
+++ b/ee/controllers/phjob_controller.go
@@ -429,10 +429,16 @@ func (r *PhJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		log.Info("phJob has finished, reconcile it after ttl.", "ttlDuration", ttlDuration)
 		return ctrl.Result{RequeueAfter: ttlDuration}, nil
 	} else if phJob.Status.StartTime != nil && *phJob.Spec.ActiveDeadlineSeconds != int64(0) { // Job in Running
-		activeDeadlineSeconds := time.Second * time.Duration(*phJob.Spec.ActiveDeadlineSeconds)
-		next := phJob.Status.StartTime.Add(activeDeadlineSeconds).Sub(time.Now())
-		log.Info("phJob is still running, reconcile it after for active deadline", "next", next)
-		return ctrl.Result{RequeueAfter: next}, nil
+		//activeDeadlineSeconds := time.Second * time.Duration(*phJob.Spec.ActiveDeadlineSeconds)
+		//next := phJob.Status.StartTime.Add(activeDeadlineSeconds).Sub(time.Now())
+		//log.Info("phJob is still running, reconcile it after for active deadline", "next", next)
+
+		// NOTE: we disable the long requeue after upgrade for 1.24
+
+		// There is no other way to make a running job switch to the next phase in this execution branch,
+		// so we need the frequent checking the state for the running job.
+		log.Info("phJob is still running, reconcile it after next-check", "next", nextCheck)
+		return ctrl.Result{RequeueAfter: nextCheck}, nil
 	}
 
 	return ctrl.Result{RequeueAfter: nextCheck}, nil


### PR DESCRIPTION

** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

Bugfix

**What this PR does / why we need it**:

In the newer k8s, PhJob might not switch its status from Running to Success, caused by the long requeue events.
